### PR TITLE
Fix URL for Open Hardware Monitor 0.9.6

### DIFF
--- a/automatic/openhardwaremonitor/tools/chocolateyInstall.ps1
+++ b/automatic/openhardwaremonitor/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 $packageName = 'openhardwaremonitor'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url = 'https://openhardwaremonitor.org/files/openhardwaremonitor-v0.9.5.zip'
+$url = 'https://openhardwaremonitor.org/files/openhardwaremonitor-v0.9.6.zip'
 $checksum = 'fc8d9148e7f56a37ac5dace9bdf08749466b605407b17a94b83cabfa3a67b4a82cf2b5e129693512c36541d15e0b3e8cd8142d8188df70f8c3bf815daa0feee0'
 $checksumType = 'sha512'
 


### PR DESCRIPTION
The package was updated to 0.9.6 but URL still points to 0.9.5.

Checksum should now match:

```
$ sha512sum.exe openhardwaremonitor-v0.9.6.zip
fc8d9148e7f56a37ac5dace9bdf08749466b605407b17a94b83cabfa3a67b4a82cf2b5e129693512c36541d15e0b3e8cd8142d8188df70f8c3bf815daa0feee0 *openhardwaremonitor-v0.9.6.zip
```