### PR TITLE
Fix broken CoolTerm 64bit windows install due to download link changing

### DIFF
--- a/automatic/coolterm/tools/chocolateyinstall.ps1
+++ b/automatic/coolterm/tools/chocolateyinstall.ps1
@@ -1,9 +1,9 @@
-﻿$packagename = 'coolterm'
+$packagename = 'coolterm'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url32 = 'https://freeware.the-meiers.org/CoolTermWin32Bit.zip'
 $checksum32 = '0f12af99ed59fd016849006587269df9a0cc361d081c3cac7dfd8522fbad4b1da25c41e4781ff28361692a95e2406082d20345228fd5d54db4ca70f9d2068186'
-$url64 = 'https://freeware.the-meiers.org/CoolTermWin.zip'
-$checksum64 = '8a4391b4ad2a05873e977e50ca0d186e63ff7e227083604582f0b0d639e5f5094da52a16f22677a08628bac151face68af79901ee3317f5a43711184baa9c532'
+$url64 = 'https://freeware.the-meiers.org/CoolTermWin64Bit.zip'
+$checksum64 = 'e1453b5c52d284233c2b3a6a9e690056e4007d9925db641b1bcdf8c4314ce8a00237c64ad2ad58fd1ec122a393b6bff9df0410568c9c3335a647370adff118e2'
 $checksumType = 'sha512'
 
 Install-ChocolateyZipPackage -PackageName "$packageName" `


### PR DESCRIPTION
[Great work, Thanks!]
Roger Meier has changed his download links for the 64 bit windows build from `https://freeware.the-meiers.org/CoolTermWin.zip` to `https://freeware.the-meiers.org/CoolTermWin64Bit.zip`. I also updated the checksum.