### PR TITLE
Update hledger chocolateyinstall.ps1 with correct hledger-windows-x64.zip URL for version 1.29.1

### DIFF
--- a/automatic/hledger/tools/chocolateyinstall.ps1
+++ b/automatic/hledger/tools/chocolateyinstall.ps1
@@ -1,6 +1,6 @@
 ﻿$ErrorActionPreference = 'Stop';
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://github.com/simonmichael/hledger/releases/download/hledger-web-1.29.1/hledger-windows-x64.zip'
+$url        = 'https://github.com/simonmichael/hledger/releases/download/1.29.1/hledger-windows-x64.zip'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName


### PR DESCRIPTION
Fix broken URL. The SHA256 checksum was correct.